### PR TITLE
goの導入と閏年判定関数, そのテスト関数の実装

### DIFF
--- a/go/util/util.go
+++ b/go/util/util.go
@@ -1,0 +1,5 @@
+package util
+
+func IsLeapYear(year int) bool {
+	return (year%4 == 0 && year%100 != 0) || (year%400 == 0)
+}

--- a/go/util/util_test.go
+++ b/go/util/util_test.go
@@ -1,0 +1,35 @@
+package util
+
+import "testing"
+
+func TestIsLeapYear(t *testing.T) {
+	type args struct {
+		year int
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+		{name: "4で割り切れる, 100で割り切れる, 400で割り切れるtest", args: args{year: 2000}, want: true},
+		{name: "4で割り切れる, 100で割り切れる, 400で割り切れるの境界値(-1)test", args: args{year: 1999}, want: false},
+		{name: "4で割り切れる, 100で割り切れる, 400で割り切れるの境界値(+1)test", args: args{year: 2001}, want: false},
+		{name: "4で割り切れる, 100で割り切れる, 400で割り切れないtest", args: args{year: 100}, want: false},
+		{name: "4で割り切れる, 100で割り切れる, 400で割り切れないの境界値(-1)test", args: args{year: 99}, want: false},
+		{name: "4で割り切れる, 100で割り切れる, 400で割り切れないの境界値(+1)test", args: args{year: 101}, want: false},
+		{name: "4で割り切れる, 100で割り切れない, 400で割り切れないtest", args: args{year: 404}, want: true},
+		{name: "4で割り切れる, 100で割り切れない, 400で割り切れないの境界値(-1)test", args: args{year: 403}, want: false},
+		{name: "4で割り切れる, 100で割り切れない, 400で割り切れないの境界値(+1)test", args: args{year: 405}, want: false},
+		{name: "4で割り切れない, 100で割り切れない, 400で割り切れないtest", args: args{year: 17}, want: false},
+		{name: "4で割り切れない, 100で割り切れない, 400で割り切れないの境界値(-1)test", args: args{year: 16}, want: true},
+		{name: "4で割り切れない, 100で割り切れない, 400で割り切れないの境界値(+1)test", args: args{year: 18}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLeapYear(tt.args.year); got != tt.want {
+				t.Errorf("IsLeapYear() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 修正内容
Goの実行環境を導入
Goでの閏年の判定関数の実装
上記判定関数のテスト関数の実装

## 確認内容
追加ファイルの内容を確認してください.


## 備考
なし

